### PR TITLE
chore(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,35 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: weekly
+    labels: [dependencies, automated, actions]
+    groups:
+      actions-minor-patch:
+        update-types: [minor, patch]
+      actions-major:
+        update-types: [major]
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: weekly
+    allow:
+      - dependency-type: development
+    labels: [dependencies, automated, dev]
+    groups:
+      npm-dev-minor-patch:
+        update-types: [minor, patch]
+      npm-dev-major:
+        update-types: [major]
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-type: production
+    labels: [dependencies, automated, prod]
+    groups:
+      npm-prod-minor-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
Добавил еженедельное обновление зависимостей через Dependabot

Для экшенов будет формироваться комплексный ПР с минорными изменениями и патчами. Изменения мажорных версий так же идут батчем в отдельном ПР

Зависимости npm разделены на две группы:

- Под лейблом `dev` обновляются _devDependencies_. Мажорные версии изменений объеденяются в один ПР так же как для экшенов
- Под лейблом `prod` обновляются все остальные за исключением _peerDependencies_. Обновление каждой мажорной версии идет индивидуальным ПРом

fyi @fey
